### PR TITLE
:see_no_evil: .vscode 파일 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .turbo
 node_modules
+.vscode


### PR DESCRIPTION
팀원 모두가 vscode를 쓰긴 하지만, 자칫 프로젝트가 vscode에 종속적이어질 수 있으므로 사전에 방지하여 vscode 파일이 깃에 추적되지 않게 하는 게 좋을 것 같습니다.